### PR TITLE
using ensurenl=False to hide the j character after def

### DIFF
--- a/src/pygame_texteditor/TextEditor.py
+++ b/src/pygame_texteditor/TextEditor.py
@@ -200,7 +200,7 @@ class TextEditor:
         self.color_text = (255, 255, 255)
         self.color_caret = (255, 255, 255)
 
-        self.lexer = PythonLexer()
+        self.lexer = PythonLexer(ensurenl=False)
         self.color_formatter = ColorFormatter()
         self.set_colorscheme(style)
 


### PR DESCRIPTION
Fixes https://github.com/CribberSix/pygame-texteditor/issues/18

I'm not sure why, but if you type `def ` (notice the space), the code in `get_syntax_coloring_dicts` returns a list of two dictionaries, the first of which has a value of `"def"` and the second of which has `" \n"`.

And for some reason, this newline character gets rendered in the code editor as a "j".

I found this issue https://github.com/pygments/pygments/issues/610 that says to use `ensurenl=False` to make the newline character go away. Doing so consequently makes the "j" go away.

Probably worth a more detailed investigation by the maintainers.