### PR TITLE
increasing default window width in the how-to-use.py example

### DIFF
--- a/how-to-use.py
+++ b/how-to-use.py
@@ -4,7 +4,7 @@ from pygame_texteditor import TextEditor
 
 # minimal pygame setup
 pygame.init()
-screen = pygame.display.set_mode((500, 600))
+screen = pygame.display.set_mode((600, 600))
 pygame.display.set_caption("Pygame")
 pygame.display.get_surface().fill((200, 200, 200))  # background coloring
 


### PR DESCRIPTION
I feel this looks better. In the current example, the editor comes right up against the right side of the window, and it looks like a bug. The first time I saw it, I thought I'd done something wrong

old:
<img width="848" alt="Cap" src="https://github.com/CribberSix/pygame-texteditor/assets/30541183/fa8a9674-d301-41cc-a36d-4d209ba2c9a0">

new:
<img width="825" alt="cap2" src="https://github.com/CribberSix/pygame-texteditor/assets/30541183/41b4cc6a-c977-4409-9f3f-29b4b9baaa2d">